### PR TITLE
Catch C++ exceptions at extern C boundary (#8)

### DIFF
--- a/prog/src/main/cpp/common.h
+++ b/prog/src/main/cpp/common.h
@@ -29,7 +29,33 @@ extern "C" {
 #include <typeinfo>
 #include <vector>
 #include <algorithm>
+#include <cstring>
 #include <memory>
+
+// Thread-local error state for C API boundary
+struct SboxError {
+    bool hasError;
+    char message[256];
+};
+
+// Use __thread for C++11 compatibility (thread_local also works but __thread is simpler for POD)
+extern __thread SboxError g_sboxLastError;
+
+inline void clearSboxError() {
+    g_sboxLastError.hasError = false;
+    g_sboxLastError.message[0] = '\0';
+}
+
+inline void setSboxError(const char* msg) {
+    g_sboxLastError.hasError = true;
+    strncpy(g_sboxLastError.message, msg, sizeof(g_sboxLastError.message) - 1);
+    g_sboxLastError.message[sizeof(g_sboxLastError.message) - 1] = '\0';
+}
+
+// Macros for wrapping extern "C" functions
+#define SBOX_TRY try { clearSboxError();
+#define SBOX_CATCH } catch (const std::exception& e) { setSboxError(e.what()); } catch (...) { setSboxError("Unknown C++ exception"); }
+#define SBOX_CATCH_RETURN(default_val) } catch (const std::exception& e) { setSboxError(e.what()); return default_val; } catch (...) { setSboxError("Unknown C++ exception"); return default_val; }
 
 #include <ga/std_stream.h>
 #include <ga/GASimpleGA.h>

--- a/prog/src/main/cpp/main.cpp
+++ b/prog/src/main/cpp/main.cpp
@@ -16,6 +16,17 @@
  */
 #include "main.h"
 
+__thread SboxError g_sboxLastError = {false, {0}};
+
+bool hasError() {
+	return g_sboxLastError.hasError;
+}
+
+const char* getLastError() {
+	return g_sboxLastError.message;
+}
+
+
 void setParameters(SboxSearchAlgorithmBase & ga, const int popsize, const int ngen, const float pmut, const float pcross,
 		const int bestGenomes)
 {
@@ -33,25 +44,31 @@ inline void setParameters(SboxSearchAlgorithmBase & ga, const int popsize, const
 }
 
 TSearching newParallelRandomSearching(TGenome genome, int popsize, int ngen, float pMut) {
+	SBOX_TRY
 	std::unique_ptr<ParallelRandomSearchAlgorithm> ga(new ParallelRandomSearchAlgorithm(*genome.ptr));
 	setParameters(*ga, popsize, ngen, pMut, 0.0);
 	TSearching searching = {ga.release()};
 	return searching;
+	SBOX_CATCH_RETURN(TSearching{NULL})
 }
 
 TSearching newEdaSearching(TGenome g, int popsize, int ngen, bool bdma) {
+	SBOX_TRY
 	std::unique_ptr<EstimationOfDistributionAlgorithm> ga(new EstimationOfDistributionAlgorithm(*g.ptr, bdma, popsize));
 	setParameters(*ga, popsize, ngen, 0.0, 0.0);
 	TSearching searching = {ga.release()};
 	return searching;
+	SBOX_CATCH_RETURN(TSearching{NULL})
 }
 
 TSearching newGaSearching(TGenome g, int popsize, int ngen, float pMut, float pCross, bool elitism) {
+	SBOX_TRY
 	std::unique_ptr<SboxSearchAlgorithmBase> ga(new SboxSearchAlgorithmBase(*g.ptr));
 	setParameters(*ga, popsize, ngen, pMut, pCross);
 	ga->elitist(toGABool(elitism));
 	TSearching searching = {ga.release()};
 	return searching;
+	SBOX_CATCH_RETURN(TSearching{NULL})
 }
 
 void ParallelRandomSearchAlgorithm::step() {
@@ -84,10 +101,12 @@ void RandomSearchAlgorithm::step()
 // u nahodneho prohledavani se neda hovorit o velikosti populace, ale
 // toto cislo se da pouzit k nastaveni kolik nejlepsich jedincu se ma ulozit
 TSearching newRandomSearching(TGenome g, int bestGenomes, int ngen) {
+	SBOX_TRY
 	std::unique_ptr<RandomSearchAlgorithm> ga(new RandomSearchAlgorithm(*g.ptr));
 	setParameters(*ga, 1, ngen, 0.1, 0, bestGenomes);
 	TSearching searching = {ga.release()};
 	return searching;
+	SBOX_CATCH_RETURN(TSearching{NULL})
 }
 
 void HeuristicSearchAlgorithm::evolve(unsigned int seed){
@@ -114,10 +133,12 @@ void HeuristicSearchAlgorithm::evolve(unsigned int seed){
 }
 
 TSearching newHeuristicSearching(TGenome g, uint maxStates, uint ngen) {
+	SBOX_TRY
 	std::unique_ptr<HeuristicSearchAlgorithm> ga(new HeuristicSearchAlgorithm(*g.ptr, maxStates));
 	setParameters(*ga, 1, maxStates, ngen, 0);
 	TSearching searching = {ga.release()};
 	return searching;
+	SBOX_CATCH_RETURN(TSearching{NULL})
 }
 
 inline const CriterionsSet createCriterionsSet(const int criterionsCount, const CriterionsFitness *criterions) {
@@ -128,17 +149,21 @@ inline const CriterionsSet createCriterionsSet(const int criterionsCount, const 
 }
 
 TSearching newVegaSearching(TGenome g, int popsize, int ngen, float pMut, float pCross, const int criterionsCount, const CriterionsFitness *criterions) {
+	SBOX_TRY
 	std::unique_ptr<VegaAlgorithm> ga(new VegaAlgorithm(*g.ptr, createCriterionsSet(criterionsCount, criterions)));
 	setParameters(*ga, popsize, ngen, pMut, pCross);
 	TSearching searching = {ga.release()};
 	return searching;
+	SBOX_CATCH_RETURN(TSearching{NULL})
 }
 
 TSearching newSpeaSearching(TGenome g, int popsize, int ngen, float pMut, float pCross, const int criterionsCount, const CriterionsFitness *criterions) {
+	SBOX_TRY
 	std::unique_ptr<SpeaAlgorithm> ga(new SpeaAlgorithm(*g.ptr, createCriterionsSet(criterionsCount, criterions)));
 	setParameters(*ga, popsize, ngen, pMut, pCross);
 	TSearching searching = {ga.release()};
 	return searching;
+	SBOX_CATCH_RETURN(TSearching{NULL})
 }
 
 TGenome privateCreateGenome(GenomeType type, GAGenome::Evaluator evaluator, const intVector & arguments) {
@@ -188,15 +213,18 @@ for (int i=0; i < argc; i++) arguments.push_back(va_arg(args, int));\
 va_end(args);\
 
 TGenome createGenome(GenomeType type, CriterionsFitness criterion, int argc, ...) {
+	SBOX_TRY
 	VARARGS_TO_VECTOR
 
 	GAGenome::Evaluator evaluator = criterionsEnumToFunction(criterion);
 	TGenome privateCreateGenome0 = privateCreateGenome(type, evaluator, arguments);
 	/*report << privateCreateGenome0.ptr << endl;*/
 	return privateCreateGenome0;
+	SBOX_CATCH_RETURN(TGenome{NULL})
 }
 
 TGenome createSymbolicalRegresionGenome(GenomeType type, int *expectedOutputs, int argc, ...) {
+	SBOX_TRY
 	VARARGS_TO_VECTOR
 
 	GAGenome::Evaluator evaluator = symbolicalRegresionObjective;
@@ -205,9 +233,11 @@ TGenome createSymbolicalRegresionGenome(GenomeType type, int *expectedOutputs, i
 	intVector *outputs = new intVector(expectedOutputs, expectedOutputs+(1<<sbox->inputsCount()));
 	sbox->setExpectedValues(outputs);
 	return genome;
+	SBOX_CATCH_RETURN(TGenome{NULL})
 }
 
 void processSearching(TSearching searching, TerminatorCondition condition, uint seed) {
+	SBOX_TRY
 	GAGeneticAlgorithm *ga = searching.algorithm;
 	switch (condition) {
 		case GENERATION:
@@ -225,13 +255,46 @@ void processSearching(TSearching searching, TerminatorCondition condition, uint 
 			break;
 	}
 	ga->evolve(seed);
+	SBOX_CATCH
 }
 
 void parallelProcessSearching(const int taskCount, const TSearching tasks[], TerminatorCondition condition, const uint seeds[]) {
+	SBOX_TRY
+	bool anyError = false;
+	char firstError[256] = {0};
 	#pragma omp parallel for schedule(guided) default(shared)
 	for (int i = 0; i < taskCount; i++) {
-		processSearching(tasks[i], condition, seeds[i]);
+		try {
+			GAGeneticAlgorithm *ga = tasks[i].algorithm;
+			switch (condition) {
+				case GENERATION:
+					ga->terminator(GAGeneticAlgorithm::TerminateUponGeneration);
+					break;
+				case CONVERGENCE:
+					ga->terminator(GAGeneticAlgorithm::TerminateUponConvergence);
+					break;
+				case POPCONVERGENCE:
+					ga->terminator(GAGeneticAlgorithm::TerminateUponPopConvergence);
+					break;
+				default:
+					throw std::runtime_error("Wrong type of terminator specified");
+			}
+			ga->evolve(seeds[i]);
+		} catch (const std::exception& e) {
+			#pragma omp critical
+			{
+				if (!anyError) {
+					strncpy(firstError, e.what(), 255);
+					firstError[255] = '\0';
+					anyError = true;
+				}
+			}
+		}
 	}
+	if (anyError) {
+		throw std::runtime_error(std::string("Error in parallel search: ") + firstError);
+	}
+	SBOX_CATCH
 }
 
 
@@ -275,6 +338,7 @@ inline void simpleReportAboutGenome(std::ostream & out, GAGenome & individual) t
 }
 
 PyObject* simpleReportSearching(TSearching searching) {
+	SBOX_TRY
 	SboxSearchAlgorithmBase *ga = searching.algorithm;
 	GAPopulation population = ga->bestResults();
 	std::ostringstream out;
@@ -288,24 +352,33 @@ PyObject* simpleReportSearching(TSearching searching) {
 	}
 
 	return createPythonString(out.str());
+	SBOX_CATCH_RETURN(NULL)
 }
 
 void testSoftwareBox() {
+	SBOX_TRY
 	SoftwareSboxGenome genome = SoftwareSboxGenome::testBox();
 	genome.evaluator(bentAndMosacObjective);
 	simpleReportAboutGenome(std::cout, genome);
+	SBOX_CATCH
 }
 
 void closeSearching(TSearching searching) {
+	SBOX_TRY
 	freeAndNULL(searching.algorithm);
+	SBOX_CATCH
 }
 
 void closeGenome(TGenome genome) {
+	SBOX_TRY
 	freeAndNULL(genome.ptr);
+	SBOX_CATCH
 }
 
 void setMiniMaxiSearching(TSearching searching, bool minimize) {
+	SBOX_TRY
 	searching.algorithm->minimaxi(minimize ? GAGeneticAlgorithm::MINIMIZE : GAGeneticAlgorithm::MAXIMIZE);
+	SBOX_CATCH
 }
 
 inline void arrayConv(const GAPopulation &population, float *&result) {
@@ -315,6 +388,7 @@ inline void arrayConv(const GAPopulation &population, float *&result) {
 }
 
 TStatistics getStatisticsSearching(TSearching searching, float *bestPopulationScores, float *bestPopulationCriterionsValues, int *bestPopulationOutputs) {
+	SBOX_TRY
 	const GAStatistics &stats = searching.algorithm->statistics();
 	// nepouzije se posledni generace, ale populace nejlepsich jedincu ze statistik
 	// (nejen proto, aby se dalo srovnavat s nahodnym prohledavanim)
@@ -348,9 +422,11 @@ TStatistics getStatisticsSearching(TSearching searching, float *bestPopulationSc
 	result.replacements = stats.replacements();
 	result.nBestGenomes = population.size();
 	return result;
+	SBOX_CATCH_RETURN(TStatistics{})
 }
 
 PyObject* bestPopulationStringsSearching(TSearching searching) {
+	SBOX_TRY
 	const GAPopulation &population = searching.algorithm->bestResults();
 	PyObject* list = PyList_New(population.size());
 	for (int i = 0; i < population.size(); i++) {
@@ -359,6 +435,7 @@ PyObject* bestPopulationStringsSearching(TSearching searching) {
 		PyList_SET_ITEM(list, i, createPythonString(out.str()));
 	}
 	return list;
+	SBOX_CATCH_RETURN(NULL)
 }
 
 //kdyby se standardni coredump nehodil...
@@ -380,6 +457,7 @@ PyObject* bestPopulationStringsSearching(TSearching searching) {
 //}
 //
 void initialization() {
+	SBOX_TRY
 //	errno = 0;
 //	signal(SIGABRT, handler);
 //	if (errno) {
@@ -392,4 +470,5 @@ void initialization() {
 //		exit(1);
 //	}
 ////	std::set_terminate(terminateWithStackTrace);
+	SBOX_CATCH
 }

--- a/prog/src/main/cpp/main.cpp
+++ b/prog/src/main/cpp/main.cpp
@@ -289,6 +289,15 @@ void parallelProcessSearching(const int taskCount, const TSearching tasks[], Ter
 					anyError = true;
 				}
 			}
+		} catch (...) {
+			#pragma omp critical
+			{
+				if (!anyError) {
+					strncpy(firstError, "Unknown C++ exception", 255);
+					firstError[255] = '\0';
+					anyError = true;
+				}
+			}
 		}
 	}
 	if (anyError) {

--- a/prog/src/main/cpp/main.h
+++ b/prog/src/main/cpp/main.h
@@ -99,6 +99,9 @@ extern "C" { // je treba ceckova deklarace...
 
 	void testSoftwareBox();
 	void initialization();
+
+	bool hasError();
+	const char* getLastError();
 }
 
 class RandomSearchAlgorithm : public SboxSearchAlgorithmBase {

--- a/prog/src/main/python/evolution.py
+++ b/prog/src/main/python/evolution.py
@@ -56,6 +56,18 @@ libsboxevolution = _load_sbox_library()
 libsboxevolution.simpleReportSearching.restype = ctypes.py_object
 libsboxevolution.bestPopulationStringsSearching.restype = ctypes.py_object
 
+# Configure error checking functions
+libsboxevolution.hasError.restype = ctypes.c_bool
+libsboxevolution.hasError.argtypes = []
+libsboxevolution.getLastError.restype = ctypes.c_char_p
+libsboxevolution.getLastError.argtypes = []
+
+def _check_sbox_error():
+    """Check for C++ errors after library calls and raise Python exception."""
+    if libsboxevolution.hasError():
+        msg = libsboxevolution.getLastError()
+        raise RuntimeError(f"sboxevolution error: {msg.decode('utf-8')}")
+
 # python/ceckove enumy
 class Enum(object):
     def __init__(self, enumerate, name, ordinal):
@@ -155,6 +167,7 @@ class Searching:
         #print hex(genome.delegat.ptr)
         func.restype = TSearching
         self.delegat = func(genome.delegat, *args)
+        _check_sbox_error()
         self.repr = '%s searching with population size: %d and generation count: %d\ngenome: %s\n%s' % (algorithm, self.popSize, nGen, genome, specificRepr)
 
         self.algorithm = algorithm
@@ -164,7 +177,11 @@ class Searching:
     def __getattr__(self, name):
         if name in ["__getstate__", "__setstate__", "__getinitargs__"]:
             raise AttributeError
-        return lambda *args: libsboxevolution.__getattr__(name+"Searching")(self.delegat, *args)
+        def wrapper(*args):
+            result = libsboxevolution.__getattr__(name+"Searching")(self.delegat, *args)
+            _check_sbox_error()
+            return result
+        return wrapper
 
     def simpleReport(self):
         print(self)
@@ -203,6 +220,7 @@ class Searching:
         bestPopulationOutputs = numpy.empty([self.popSize, 2**self.inputsCount], dtype=ctypes.c_int)
 
         stats = libsboxevolution.getStatisticsSearching(self.delegat, bestScores, bestPopulationCriterionsValues, bestPopulationOutputs)
+        _check_sbox_error()
         stats.bestPopulationScores = bestScores[0:stats.nBestGenomes]
         stats.bestPopulationCriterionsValues = bestPopulationCriterionsValues[0:stats.nBestGenomes]
         stats.bestPopulationOutputs = bestPopulationOutputs[0:stats.nBestGenomes]
@@ -228,6 +246,7 @@ class Searching:
             seedArray[i] = cls.randomSeed()
 
         libsboxevolution.parallelProcessSearching(len(list), array, terminator.ordinal, seedArray)
+        _check_sbox_error()
 
     @classmethod
     def parallelSimpleSearching(cls, list, terminator=TerminationCondition.GENERATION):
@@ -253,6 +272,7 @@ class Genome:
         libsboxevolution.createGenome.argtypes = [ctypes.c_uint, ctypes.c_uint, ctypes.c_int] + [ctypes.c_int]*l
         libsboxevolution.createGenome.restype = TGenome
         self.delegat = libsboxevolution.createGenome(type.ordinal, criterionFunction.ordinal, l, *args)
+        _check_sbox_error()
 
         #print "init", hex(self.delegat.ptr)
         self.setInputsAndOutputs(type, *args)
@@ -309,6 +329,7 @@ class SymbolicalRegresionGenome(Genome):
         libsboxevolution.createSymbolicalRegresionGenome.argtypes = [ctypes.c_uint, numpy.ctypeslib.ndpointer(dtype = ctypes.c_int), ctypes.c_int] + [ctypes.c_int]*l
         libsboxevolution.createSymbolicalRegresionGenome.restype = TGenome
         self.delegat = libsboxevolution.createSymbolicalRegresionGenome(type.ordinal, numpy.asarray(expectedOutputs, dtype=ctypes.c_int), l, *args)
+        _check_sbox_error()
 
         self.repr = '%s %s' % (type, args)
         self.repr += ' symbolical regresion '

--- a/prog/src/test/python/test_routines.py
+++ b/prog/src/test/python/test_routines.py
@@ -139,16 +139,27 @@ def test_error_propagation_invalid_genome_type():
     """Test that C++ errors are properly propagated to Python as RuntimeError."""
     import ctypes
 
-    # Use an invalid genome type ordinal to trigger an error
-    libsboxevolution.createGenome.argtypes = [ctypes.c_uint, ctypes.c_uint, ctypes.c_int, ctypes.c_int, ctypes.c_int]
-    libsboxevolution.createGenome.restype = TGenome
+    prev_argtypes = getattr(libsboxevolution.createGenome, "argtypes", None)
+    prev_restype = getattr(libsboxevolution.createGenome, "restype", None)
 
-    # Type 99 doesn't exist - should trigger "Wrong type of genome specified" error
-    result = libsboxevolution.createGenome(99, 0, 2, 4, 4)
+    try:
+        # Use an invalid genome type ordinal to trigger an error
+        libsboxevolution.createGenome.argtypes = [ctypes.c_uint, ctypes.c_uint, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+        libsboxevolution.createGenome.restype = TGenome
 
-    # Check that error was set
-    assert_that(libsboxevolution.hasError()).is_true()
-    error_msg = libsboxevolution.getLastError().decode('utf-8')
-    assert_that(error_msg).contains("Wrong type of genome")
+        # Type 99 doesn't exist - should trigger "Wrong type of genome specified" error
+        result = libsboxevolution.createGenome(99, 0, 2, 4, 4)
+
+        # Check that error was set at the C API level
+        assert_that(libsboxevolution.hasError()).is_true()
+        error_msg = libsboxevolution.getLastError().decode('utf-8')
+        assert_that(error_msg).contains("Wrong type of genome")
+
+        # Verify Python-side propagation raises RuntimeError
+        with pytest.raises(RuntimeError, match="Wrong type of genome"):
+            _check_sbox_error()
+    finally:
+        libsboxevolution.createGenome.argtypes = prev_argtypes
+        libsboxevolution.createGenome.restype = prev_restype
 
 

--- a/prog/src/test/python/test_routines.py
+++ b/prog/src/test/python/test_routines.py
@@ -1,4 +1,5 @@
 from assertpy import assert_that
+import pytest
 
 from evolution import (
     Genome,
@@ -9,6 +10,9 @@ from evolution import (
     SymbolicalRegresionGenome,
     picleSaveTo,
     pickleLoadFrom,
+    libsboxevolution,
+    TGenome,
+    _check_sbox_error,
 )
 
 
@@ -118,16 +122,33 @@ def test_genome_use_after_close():
     """Test that using a genome after close() is handled safely."""
     genome = Genome(ChromozomeType.PERMUTATION, CriterionFunction.LP_MAX, True, 4, 4)
     assert_that(genome.delegat.ptr).is_not_none()
-    
+
     # Close the genome
     genome.close()
-    
+
     # After close, the pointer should be None
     assert_that(genome.delegat.ptr).is_none()
     assert_that(genome._closed).is_true()
-    
+
     # Double close should be safe (idempotent)
     genome.close()
     assert_that(genome._closed).is_true()
+
+
+def test_error_propagation_invalid_genome_type():
+    """Test that C++ errors are properly propagated to Python as RuntimeError."""
+    import ctypes
+
+    # Use an invalid genome type ordinal to trigger an error
+    libsboxevolution.createGenome.argtypes = [ctypes.c_uint, ctypes.c_uint, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+    libsboxevolution.createGenome.restype = TGenome
+
+    # Type 99 doesn't exist - should trigger "Wrong type of genome specified" error
+    result = libsboxevolution.createGenome(99, 0, 2, 4, 4)
+
+    # Check that error was set
+    assert_that(libsboxevolution.hasError()).is_true()
+    error_msg = libsboxevolution.getLastError().decode('utf-8')
+    assert_that(error_msg).contains("Wrong type of genome")
 
 


### PR DESCRIPTION
## Summary
- Add thread-local error state (SboxError struct with __thread storage) to safely catch C++ exceptions at the extern C boundary, preventing undefined behavior when exceptions would otherwise propagate across language boundaries
- Wrap all extern C functions in main.cpp with SBOX_TRY/SBOX_CATCH macros that store error messages in thread-local state
- Add hasError()/getLastError() C API functions and Python _check_sbox_error() helper that raises RuntimeError after every C library call
- Special OpenMP handling in parallelProcessSearching: per-thread exception catching with pragma omp critical to capture the first error

## Details
Closes #8

**C++ side (common.h, main.h, main.cpp):**
- SboxError POD struct with 256-byte message buffer, using __thread for thread-local storage (compatible with OpenMP)
- SBOX_TRY clears error state, SBOX_CATCH catches std::exception and unknown exceptions
- SBOX_CATCH_RETURN(default_val) variant for functions with return values (returns NULL/zero-initialized struct on error)
- All 17 extern C functions wrapped including disabled PyObject* functions

**Python side (evolution.py):**
- _check_sbox_error() called after: Searching.__init__, Searching.__getattr__ (delegated calls), Searching.statistics(), Searching.parallelSearching(), Genome.__init__, SymbolicalRegresionGenome.__init__

**Test (test_routines.py):**
- test_error_propagation_invalid_genome_type: passes invalid genome type (99) to createGenome, verifies error flag is set with expected message

## Test plan
- [x] Docker build passes (docker-compose build prog)
- [x] All 16 tests pass (12 routines + 4 experiments)
- [x] New error propagation test validates C++ to Python error flow

Generated with Claude Code