### PR TITLE
Fix #12: remove Python C API dependency from ctypes library

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,6 @@ This is a Master's thesis project from Brno University of Technology, Faculty of
   - Environment-based library loading via SBOX_LIBRARY_PATH
   - Optimized Docker multi-stage build (removed build tools from runtime)
   - **Debian Package Distribution**: Docker build now creates `libsboxevolution_2.0.0_amd64.deb` package that installs library to `/usr/lib/` following FHS standards
-  - **Known Limitation**: Two Python C API functions (`simpleReportSearching()` and `bestPopulationStringsSearching()`) are disabled due to architectural constraints with ctypes-loaded libraries. Use `statistics().bestPopulationOutputs` for S-box data instead.
 - **March 2026**: Comprehensive test suite
   - C++ upgraded from C++98 to **C++11** (`-std=gnu++11`)
   - **Catch2 v2** (single-header) for C++ unit tests: 55 test cases, 1035 assertions
@@ -626,13 +625,6 @@ stats.bestPopulationOutputs          # S-box lookup tables [popSize, 2^inputs]
 - Set `SBOX_LIBRARY_PATH` environment variable for local development
 - All unit tests pass successfully with pytest 8.3+
 - Docker multi-stage build with test gates (Valgrind + Catch2 + pytest must all pass)
-
-**Known Architectural Limitation**:
-- Two C++ functions permanently disabled due to ctypes/Python C API incompatibility:
-  - `simpleReportSearching()` - detailed evolution report (commented out)
-  - `bestPopulationStringsSearching()` - string representation of S-boxes (returns empty list)
-- **Root Cause**: Libraries loaded via `ctypes.CDLL` cannot safely call Python C API functions like `PyUnicode_FromStringAndSize()` to create Python objects. This would require converting the entire codebase to use Python extension modules instead of ctypes.
-- **Workaround**: All core functionality works perfectly. Use `statistics().bestPopulationOutputs` (integer arrays) and `statistics().bestPopulationScores` instead of string representations.
 
 ### GAlib Integration
 - The project relies on **GAlib 2.4.7** (included as tarball)

--- a/README.md
+++ b/README.md
@@ -634,7 +634,6 @@ search = Searching("Ga", genome, popSize=50, nGen=5, pMut=0.1, pCross=0.9)
 ## Known Limitations
 
 - **✓ Migrated to Python 3.13** (January 2025): Successfully ported from Python 2.x
-  - **Architectural Constraint**: Two C++ functions (`simpleReportSearching()`, `bestPopulationStringsSearching()`) disabled due to ctypes/Python C API incompatibility. Use `statistics().bestPopulationOutputs` instead.
 - **Legacy Dependencies**: GAlib 2.4.7 (2001), C++98 standard
 - **Platform-Specific** (Native builds only): Makefile hardcodes AMD K8 architecture flags
   - **✓ Resolved by Docker**: Automatic patching for modern compilers and architectures

--- a/prog/Dockerfile
+++ b/prog/Dockerfile
@@ -47,7 +47,7 @@ RUN make
 # ============================================
 # Stage 2: Build libsboxevolution.so
 # ============================================
-FROM python:3.14-slim AS sbox-builder
+FROM debian:bookworm-slim AS sbox-builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -71,13 +71,11 @@ WORKDIR /build/sboxEvolver/prog
 # 1. Change g++-4.4 to g++ (use default compiler)
 # 2. Change -march=k8-sse3 to -march=native (optimize for build machine)
 # 3. Fix GAlib path to match Docker directory structure
-# 4. Add Python 3.14 library linkage for Python C API functions
 RUN sed -i 's|CXX = g++-4.4|CXX = g++|g' makefile && \
     sed -i 's|-std=gnu++98|-std=gnu++11|g' makefile && \
     sed -i 's|-march=k8-sse3|-march=native|g' makefile && \
     sed -i 's|-I../galib247/|-I../../galib247|g' makefile && \
-    sed -i 's|-L../galib247/ga|-L../../galib247/ga|g' makefile && \
-    sed -i 's|CXX_LIBS=-lga -lm|CXX_LIBS=-lga -lm -lpython3.14|g' makefile
+    sed -i 's|-L../galib247/ga|-L../../galib247/ga|g' makefile
 
 # Patch project's template code for modern C++ (same issue as GAlib)
 RUN sed -i 's/\tinitializer(/\tthis->initializer(/g' src/main/cpp/boxes.h && \
@@ -192,9 +190,8 @@ COPY prog/src/test/cpp/ src/test/cpp/
 RUN g++ -std=gnu++11 -ggdb3 -fopenmp -march=native -O0 \
     -Isrc/main/cpp \
     -I../../galib247/ -L../../galib247/ga \
-    -I/usr/local/include/python3.14 \
     -o valgrind_test src/test/cpp/valgrind_test.cpp \
-    -L. -lsboxevolution -lga -lm -lpython3.14
+    -L. -lsboxevolution -lga -lm
 
 # Run valgrind (--error-exitcode=1 fails the build on leaks)
 RUN LD_LIBRARY_PATH=. valgrind \
@@ -219,10 +216,9 @@ RUN g++ -std=gnu++11 -ggdb3 -fopenmp -march=native -O2 \
     -Isrc/main/cpp \
     -I../../galib247/ -L../../galib247/ga \
     -Isrc/test/cpp \
-    -I/usr/local/include/python3.14 \
     -o cpp_tests \
     src/test/cpp/test_*.cpp \
-    -L. -lsboxevolution -lga -lm -lpython3.14
+    -L. -lsboxevolution -lga -lm
 
 # Run C++ unit tests
 RUN LD_LIBRARY_PATH=. ./cpp_tests
@@ -244,10 +240,9 @@ RUN g++ -std=gnu++11 -ggdb3 -fopenmp -march=native -O2 \
     -Isrc/main/cpp \
     -I../../galib247/ -L../../galib247/ga \
     -Isrc/test/cpp \
-    -I/usr/local/include/python3.14 \
     -o cpp_benchmarks \
     src/test/cpp/bench_*.cpp \
-    -L. -lsboxevolution -lga -lm -lpython3.14
+    -L. -lsboxevolution -lga -lm
 
 # Run benchmarks
 RUN LD_LIBRARY_PATH=. ./cpp_benchmarks

--- a/prog/makefile
+++ b/prog/makefile
@@ -24,7 +24,7 @@ HEADS=common.h eda.h cgp.h criterions.h main.h softwareSbox.h multicriterial.h
 DEBUG_FLAGS = -ggdb3
 PROD_FLAGS = -DNDEBUG
 CURRENT_FLAGS = $(DEBUG_FLAGS)
-FLAGS= -W -Wall -std=gnu++11 $(CURRENT_FLAGS) -fopenmp -march=k8-sse3 -O3 -I../galib247/ -L../galib247/ga -I/usr/local/include/python3.14
+FLAGS= -W -Wall -std=gnu++11 $(CURRENT_FLAGS) -fopenmp -march=k8-sse3 -O3 -I../galib247/ -L../galib247/ga
 CXX_LIBS=-lga -lm
 
 .SUFFIXES: .cpp

--- a/prog/src/main/cpp/common.h
+++ b/prog/src/main/cpp/common.h
@@ -21,10 +21,6 @@
 #include <stdexcept>
 #include <string>
 
-extern "C" {
-	#include <Python.h>
-}
-
 #include <cmath>
 #include <typeinfo>
 #include <vector>
@@ -81,11 +77,6 @@ inline int binaryDot(int x, int y) {
 	// * == & paralelne ;)
 	// suma - suda/licha hammingova vaha
 	return is_odd(hammingWeight(x & y));
-}
-
-inline PyObject* createPythonString(const std::string & str) {
-	// Python 3 uses PyUnicode for string objects (PyString removed)
-	return PyUnicode_FromStringAndSize(str.c_str(), str.size());
 }
 
 inline void stopOnError(const std::string &message) {

--- a/prog/src/main/cpp/main.cpp
+++ b/prog/src/main/cpp/main.cpp
@@ -346,7 +346,7 @@ inline void simpleReportAboutGenome(std::ostream & out, GAGenome & individual) t
 	out << endl << "Chromozome:\t" << individual << endl << endl;
 }
 
-PyObject* simpleReportSearching(TSearching searching) {
+int simpleReportSearching(TSearching searching, char* buf, int bufSize) {
 	SBOX_TRY
 	SboxSearchAlgorithmBase *ga = searching.algorithm;
 	GAPopulation population = ga->bestResults();
@@ -360,8 +360,15 @@ PyObject* simpleReportSearching(TSearching searching) {
 		simpleReportAboutGenome(out, individual);
 	}
 
-	return createPythonString(out.str());
-	SBOX_CATCH_RETURN(NULL)
+	const std::string s = out.str();
+	const int needed = (int)s.size();
+	if (buf != NULL && bufSize > 0) {
+		const int toCopy = (needed < bufSize) ? needed : (bufSize - 1);
+		memcpy(buf, s.data(), toCopy);
+		buf[toCopy] = '\0';
+	}
+	return needed;
+	SBOX_CATCH_RETURN(-1)
 }
 
 void testSoftwareBox() {
@@ -434,17 +441,24 @@ TStatistics getStatisticsSearching(TSearching searching, float *bestPopulationSc
 	SBOX_CATCH_RETURN(TStatistics{})
 }
 
-PyObject* bestPopulationStringsSearching(TSearching searching) {
+int bestPopulationStringsSearching(TSearching searching, char* buf, int bufSize) {
 	SBOX_TRY
 	const GAPopulation &population = searching.algorithm->bestResults();
-	PyObject* list = PyList_New(population.size());
+	std::ostringstream out;
 	for (int i = 0; i < population.size(); i++) {
-		std::ostringstream out;
+		if (i > 0) out << '\x1f'; // ASCII Unit Separator delimits entries
 		out << population.individual(i);
-		PyList_SET_ITEM(list, i, createPythonString(out.str()));
 	}
-	return list;
-	SBOX_CATCH_RETURN(NULL)
+
+	const std::string s = out.str();
+	const int needed = (int)s.size();
+	if (buf != NULL && bufSize > 0) {
+		const int toCopy = (needed < bufSize) ? needed : (bufSize - 1);
+		memcpy(buf, s.data(), toCopy);
+		buf[toCopy] = '\0';
+	}
+	return needed;
+	SBOX_CATCH_RETURN(-1)
 }
 
 //kdyby se standardni coredump nehodil...

--- a/prog/src/main/cpp/main.h
+++ b/prog/src/main/cpp/main.h
@@ -77,8 +77,8 @@ extern "C" { // je treba ceckova deklarace...
 	void processSearching(TSearching, TerminatorCondition, uint seed);
 	void closeSearching(TSearching);
 	void closeGenome(TGenome);
-	PyObject* simpleReportSearching(TSearching searching);
-	PyObject* bestPopulationStringsSearching(TSearching);
+	int simpleReportSearching(TSearching searching, char* buf, int bufSize);
+	int bestPopulationStringsSearching(TSearching searching, char* buf, int bufSize);
 	void setMiniMaxiSearching(TSearching, bool minimize);
 	TStatistics getStatisticsSearching(TSearching searching, float *bestPopulationScores, float *bestPopulationCriterionsValues, int *bestPopulationOutputs);
 

--- a/prog/src/main/python/evolution.py
+++ b/prog/src/main/python/evolution.py
@@ -53,8 +53,6 @@ def _load_sbox_library():
         )
 
 libsboxevolution = _load_sbox_library()
-libsboxevolution.simpleReportSearching.restype = ctypes.py_object
-libsboxevolution.bestPopulationStringsSearching.restype = ctypes.py_object
 
 # Configure error checking functions
 libsboxevolution.hasError.restype = ctypes.c_bool
@@ -105,6 +103,12 @@ class TGenome(ctypes.Structure):
 # Configure closeGenome function signature for type safety
 libsboxevolution.closeGenome.argtypes = [TGenome]
 libsboxevolution.closeGenome.restype = None
+
+# Configure buffer-based report and string functions
+libsboxevolution.simpleReportSearching.argtypes = [TSearching, ctypes.c_char_p, ctypes.c_int]
+libsboxevolution.simpleReportSearching.restype = ctypes.c_int
+libsboxevolution.bestPopulationStringsSearching.argtypes = [TSearching, ctypes.c_char_p, ctypes.c_int]
+libsboxevolution.bestPopulationStringsSearching.restype = ctypes.c_int
 
 # zastupuje Ceckovu strukturu, pomoci ktere se predavaji statistiky behu
 class TStatistics(ctypes.Structure):
@@ -185,20 +189,31 @@ class Searching:
 
     def simpleReport(self):
         print(self)
-        # NOTE: simpleReportSearching() disabled due to architectural limitation
-        # The C++ function returns PyObject* (Python string), but when loaded via
-        # ctypes.CDLL, the library cannot safely call Python C API functions like
-        # PyUnicode_FromStringAndSize(). This would require converting to a proper
-        # Python extension module (not ctypes). Detailed stats are available via statistics().
-        # ptr = libsboxevolution.simpleReportSearching(self.delegat)
-        # print(ptr)
+        buf_size = 8192
+        buf = ctypes.create_string_buffer(buf_size)
+        needed = libsboxevolution.simpleReportSearching(self.delegat, buf, buf_size)
+        _check_sbox_error()
+        if needed >= buf_size:
+            buf_size = needed + 1
+            buf = ctypes.create_string_buffer(buf_size)
+            libsboxevolution.simpleReportSearching(self.delegat, buf, buf_size)
+            _check_sbox_error()
+        print(buf.value.decode('utf-8', errors='replace'))
 
     def bestPopulationStrings(self):
-        # NOTE: bestPopulationStringsSearching() disabled due to architectural limitation
-        # Same issue as simpleReportSearching() - cannot return PyObject* from ctypes library.
-        # Use statistics().bestPopulationOutputs to get S-box lookup tables as integers instead.
-        # return libsboxevolution.bestPopulationStringsSearching(self.delegat)
-        return []  # Return empty list to maintain compatibility
+        buf_size = 8192
+        buf = ctypes.create_string_buffer(buf_size)
+        needed = libsboxevolution.bestPopulationStringsSearching(self.delegat, buf, buf_size)
+        _check_sbox_error()
+        if needed >= buf_size:
+            buf_size = needed + 1
+            buf = ctypes.create_string_buffer(buf_size)
+            libsboxevolution.bestPopulationStringsSearching(self.delegat, buf, buf_size)
+            _check_sbox_error()
+        if needed == 0:
+            return []
+        text = buf.value.decode('utf-8', errors='replace')
+        return text.split('\x1f')
 
     def simpleEvolveAndClose(self, terminator=TerminationCondition.GENERATION):
         self.simpleEvolve(terminator)

--- a/prog/src/main/python/evolution.py
+++ b/prog/src/main/python/evolution.py
@@ -104,10 +104,12 @@ class TGenome(ctypes.Structure):
 libsboxevolution.closeGenome.argtypes = [TGenome]
 libsboxevolution.closeGenome.restype = None
 
-# Configure buffer-based report and string functions
-libsboxevolution.simpleReportSearching.argtypes = [TSearching, ctypes.c_char_p, ctypes.c_int]
+# Configure buffer-based report and string functions.
+# POINTER(c_char) is used (not c_char_p) because the buffer is written to
+# by the C side; c_char_p is for immutable NUL-terminated input strings.
+libsboxevolution.simpleReportSearching.argtypes = [TSearching, ctypes.POINTER(ctypes.c_char), ctypes.c_int]
 libsboxevolution.simpleReportSearching.restype = ctypes.c_int
-libsboxevolution.bestPopulationStringsSearching.argtypes = [TSearching, ctypes.c_char_p, ctypes.c_int]
+libsboxevolution.bestPopulationStringsSearching.argtypes = [TSearching, ctypes.POINTER(ctypes.c_char), ctypes.c_int]
 libsboxevolution.bestPopulationStringsSearching.restype = ctypes.c_int
 
 # zastupuje Ceckovu strukturu, pomoci ktere se predavaji statistiky behu

--- a/prog/src/test/python/test_routines.py
+++ b/prog/src/test/python/test_routines.py
@@ -163,3 +163,28 @@ def test_error_propagation_invalid_genome_type():
         libsboxevolution.createGenome.restype = prev_restype
 
 
+def test_simple_report_prints_convergence_and_header(capsys):
+    genome = Genome(ChromozomeType.PERMUTATION, CriterionFunction.LP_MAX, True, 4, 4)
+    search = Searching("Ga", genome, 50, 5, 0.1, 0.9, False)
+    try:
+        search.simpleEvolve(TerminationCondition.GENERATION)
+        search.simpleReport()
+        out = capsys.readouterr().out
+        assert "convergence:" in out
+        assert "Fit\tBent\tSAC\tLpMax\tDpMax\tBij\tBidir\tBF\tMinDeg\tPolynoms" in out
+    finally:
+        search.close()
+
+
+def test_best_population_strings_nonempty_list():
+    genome = Genome(ChromozomeType.PERMUTATION, CriterionFunction.LP_MAX, True, 4, 4)
+    search = Searching("Ga", genome, 50, 5, 0.1, 0.9, False)
+    try:
+        search.simpleEvolve(TerminationCondition.GENERATION)
+        strings = search.bestPopulationStrings()
+        stats = search.statistics()
+        assert isinstance(strings, list)
+        assert len(strings) == stats.nBestGenomes
+        assert all(isinstance(s, str) and len(s) > 0 for s in strings)
+    finally:
+        search.close()

--- a/prog/src/test/python/test_routines.py
+++ b/prog/src/test/python/test_routines.py
@@ -183,8 +183,10 @@ def test_best_population_strings_nonempty_list():
         search.simpleEvolve(TerminationCondition.GENERATION)
         strings = search.bestPopulationStrings()
         stats = search.statistics()
-        assert isinstance(strings, list)
-        assert len(strings) == stats.nBestGenomes
-        assert all(isinstance(s, str) and len(s) > 0 for s in strings)
+        assert_that(stats.nBestGenomes).is_greater_than(0)
+        assert_that(strings).is_instance_of(list).is_not_empty()
+        assert_that(len(strings)).is_equal_to(stats.nBestGenomes)
+        for s in strings:
+            assert_that(s).is_instance_of(str).is_not_empty()
     finally:
         search.close()


### PR DESCRIPTION
## Summary
- Replace `PyObject*` returns in `simpleReportSearching` and `bestPopulationStringsSearching` with a caller-supplied `char*` buffer protocol (grow-retry on size).
- Remove `<Python.h>` include and `createPythonString` helper from `common.h`.
- Drop `-I/usr/local/include/python3.14` from the makefile.
- Re-enable `Searching.simpleReport()` and `Searching.bestPopulationStrings()` in the Python wrapper.
- Add two pytest cases covering the restored methods.
- Remove "Known Architectural Limitation" notes from CLAUDE.md and README.md.

Closes #12.

## Test plan
- [x] `docker-compose build prog` — Valgrind 0 errors, Catch2 55 cases / 1122 assertions pass, pytest 28 passed (26 existing + 2 new)
- [x] `nm artifacts/prog/libsboxevolution.so | grep -E 'PyUnicode|PyList_|Py_Initialize'` — empty
- [x] Source-level grep confirms no `PyObject`/`PyUnicode`/`PyList_`/`createPythonString` references remain in C++